### PR TITLE
Changed tx version default to 1 to play nice with 1.3.10 wallets

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -916,6 +916,22 @@ if test "x$use_thread_local" = xyes || { test "x$use_thread_local" = xauto && te
   LDFLAGS="$TEMP_LDFLAGS"
 fi
 
+dnl check for gmtime_r(), fallback to gmtime_s() if that is unavailable
+dnl fail if neither are available.
+AC_MSG_CHECKING(for gmtime_r)
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <ctime>]],
+  [[ gmtime_r((const time_t *) nullptr, (struct tm *) nullptr); ]])],
+  [ AC_MSG_RESULT(yes); AC_DEFINE(HAVE_GMTIME_R, 1, [Define this symbol if gmtime_r is available]) ],
+  [ AC_MSG_RESULT(no);
+    AC_MSG_CHECKING(for gmtime_s);
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <ctime>]],
+       [[ gmtime_s((struct tm *) nullptr, (const time_t *) nullptr); ]])],
+       [ AC_MSG_RESULT(yes)],
+       [ AC_MSG_RESULT(no); AC_MSG_ERROR(Both gmtime_r and gmtime_s are unavailable) ]
+    )
+  ]
+)
+
 # Check for different ways of gathering OS randomness
 AC_MSG_CHECKING(for Linux getrandom syscall)
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <unistd.h>
@@ -1638,6 +1654,7 @@ AC_SUBST(EVENT_PTHREADS_LIBS)
 AC_SUBST(ZMQ_LIBS)
 AC_SUBST(PROTOBUF_LIBS)
 AC_SUBST(QR_LIBS)
+AC_SUBST(HAVE_GMTIME_R)
 AC_CONFIG_FILES([Makefile src/Makefile doc/man/Makefile share/setup.nsi share/qt/Info.plist test/config.ini])
 AC_CONFIG_FILES([contrib/devtools/split-debug.sh],[chmod +x contrib/devtools/split-debug.sh])
 AM_COND_IF([HAVE_DOXYGEN], [AC_CONFIG_FILES([doc/Doxyfile])])

--- a/libnewyorkcoinconsensus.pc
+++ b/libnewyorkcoinconsensus.pc
@@ -1,0 +1,11 @@
+prefix=/
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: Newyorkcoin consensus library
+Description: Library for the Bitcoin consensus protocol.
+Version: 0.19.0.1
+Libs: -L${libdir} -lbitcoinconsensus
+Cflags: -I${includedir}
+Requires.private: libcrypto

--- a/src/config/newyorkcoin-config.h
+++ b/src/config/newyorkcoin-config.h
@@ -1,0 +1,467 @@
+/* src/config/newyorkcoin-config.h.  Generated from newyorkcoin-config.h.in by configure.  */
+/* src/config/newyorkcoin-config.h.in.  Generated from configure.ac by autoheader.  */
+
+#ifndef BITCOIN_CONFIG_H
+
+#define BITCOIN_CONFIG_H
+
+/* Define if building universal (internal helper macro) */
+/* #undef AC_APPLE_UNIVERSAL_BUILD */
+
+/* Define this symbol if type char equals int8_t */
+/* #undef CHAR_EQUALS_INT8 */
+
+/* Version Build */
+#define CLIENT_VERSION_BUILD 1
+
+/* Version is release */
+#define CLIENT_VERSION_IS_RELEASE true
+
+/* Major version */
+#define CLIENT_VERSION_MAJOR 0
+
+/* Minor version */
+#define CLIENT_VERSION_MINOR 19
+
+/* Build revision */
+#define CLIENT_VERSION_REVISION 0
+
+/* Copyright holder(s) before %s replacement */
+#define COPYRIGHT_HOLDERS "The %s developers"
+
+/* Copyright holder(s) */
+#define COPYRIGHT_HOLDERS_FINAL "The Bitcoin Core developers"
+
+/* Replacement for %s in copyright holders string */
+#define COPYRIGHT_HOLDERS_SUBSTITUTION "Bitcoin Core"
+
+/* Copyright year */
+#define COPYRIGHT_YEAR 2019
+
+/* Define this symbol to build code that uses AVX2 intrinsics */
+#define ENABLE_AVX2 1
+
+/* Define if BIP70 support should be compiled in */
+/* #undef ENABLE_BIP70 */
+
+/* Define this symbol to build code that uses SHA-NI intrinsics */
+#define ENABLE_SHANI 1
+
+/* Define this symbol to build code that uses SSE4.1 intrinsics */
+#define ENABLE_SSE41 1
+
+/* Define to 1 to enable wallet functions */
+#define ENABLE_WALLET 1
+
+/* Define to 1 to enable ZMQ functions */
+#define ENABLE_ZMQ 1
+
+/* parameter and return value type for __fdelt_chk */
+/* #undef FDELT_TYPE */
+
+/* define if the Boost library is available */
+#define HAVE_BOOST /**/
+
+/* define if the Boost::Chrono library is available */
+#define HAVE_BOOST_CHRONO /**/
+
+/* define if the Boost::Filesystem library is available */
+#define HAVE_BOOST_FILESYSTEM /**/
+
+/* define if the Boost::System library is available */
+#define HAVE_BOOST_SYSTEM /**/
+
+/* define if the Boost::Thread library is available */
+#define HAVE_BOOST_THREAD /**/
+
+/* define if the Boost::Unit_Test_Framework library is available */
+#define HAVE_BOOST_UNIT_TEST_FRAMEWORK /**/
+
+/* Define to 1 if you have the <byteswap.h> header file. */
+/* #undef HAVE_BYTESWAP_H */
+
+/* Define this symbol if the consensus lib has been built */
+#define HAVE_CONSENSUS_LIB 1
+
+/* Define this symbol if FD_ZERO is dependent of a memcpy declaration being
+   available */
+/* #undef HAVE_CSTRING_DEPENDENT_FD_ZERO */
+
+/* define if the compiler supports basic C++11 syntax */
+#define HAVE_CXX11 1
+
+/* Define to 1 if you have the declaration of `be16toh', and to 0 if you
+   don't. */
+#define HAVE_DECL_BE16TOH 0
+
+/* Define to 1 if you have the declaration of `be32toh', and to 0 if you
+   don't. */
+#define HAVE_DECL_BE32TOH 0
+
+/* Define to 1 if you have the declaration of `be64toh', and to 0 if you
+   don't. */
+#define HAVE_DECL_BE64TOH 0
+
+/* Define to 1 if you have the declaration of `bswap_16', and to 0 if you
+   don't. */
+#define HAVE_DECL_BSWAP_16 0
+
+/* Define to 1 if you have the declaration of `bswap_32', and to 0 if you
+   don't. */
+#define HAVE_DECL_BSWAP_32 0
+
+/* Define to 1 if you have the declaration of `bswap_64', and to 0 if you
+   don't. */
+#define HAVE_DECL_BSWAP_64 0
+
+/* Define to 1 if you have the declaration of `daemon', and to 0 if you don't.
+   */
+#define HAVE_DECL_DAEMON 0
+
+/* Define to 1 if you have the declaration of `EVP_MD_CTX_new', and to 0 if
+   you don't. */
+#define HAVE_DECL_EVP_MD_CTX_NEW 0
+
+/* Define to 1 if you have the declaration of `freeifaddrs', and to 0 if you
+   don't. */
+#define HAVE_DECL_FREEIFADDRS 0
+
+/* Define to 1 if you have the declaration of `getifaddrs', and to 0 if you
+   don't. */
+#define HAVE_DECL_GETIFADDRS 0
+
+/* Define to 1 if you have the declaration of `htobe16', and to 0 if you
+   don't. */
+#define HAVE_DECL_HTOBE16 0
+
+/* Define to 1 if you have the declaration of `htobe32', and to 0 if you
+   don't. */
+#define HAVE_DECL_HTOBE32 0
+
+/* Define to 1 if you have the declaration of `htobe64', and to 0 if you
+   don't. */
+#define HAVE_DECL_HTOBE64 0
+
+/* Define to 1 if you have the declaration of `htole16', and to 0 if you
+   don't. */
+#define HAVE_DECL_HTOLE16 0
+
+/* Define to 1 if you have the declaration of `htole32', and to 0 if you
+   don't. */
+#define HAVE_DECL_HTOLE32 0
+
+/* Define to 1 if you have the declaration of `htole64', and to 0 if you
+   don't. */
+#define HAVE_DECL_HTOLE64 0
+
+/* Define to 1 if you have the declaration of `le16toh', and to 0 if you
+   don't. */
+#define HAVE_DECL_LE16TOH 0
+
+/* Define to 1 if you have the declaration of `le32toh', and to 0 if you
+   don't. */
+#define HAVE_DECL_LE32TOH 0
+
+/* Define to 1 if you have the declaration of `le64toh', and to 0 if you
+   don't. */
+#define HAVE_DECL_LE64TOH 0
+
+/* Define to 1 if you have the declaration of `strerror_r', and to 0 if you
+   don't. */
+#define HAVE_DECL_STRERROR_R 0
+
+/* Define to 1 if you have the declaration of `strnlen', and to 0 if you
+   don't. */
+#define HAVE_DECL_STRNLEN 1
+
+/* Define to 1 if you have the declaration of `__builtin_clz', and to 0 if you
+   don't. */
+#define HAVE_DECL___BUILTIN_CLZ 1
+
+/* Define to 1 if you have the declaration of `__builtin_clzl', and to 0 if
+   you don't. */
+#define HAVE_DECL___BUILTIN_CLZL 1
+
+/* Define to 1 if you have the declaration of `__builtin_clzll', and to 0 if
+   you don't. */
+#define HAVE_DECL___BUILTIN_CLZLL 1
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+/* #undef HAVE_DLFCN_H */
+
+/* Define to 1 if you have the <endian.h> header file. */
+/* #undef HAVE_ENDIAN_H */
+
+/* Define to 1 if the system has the `dllexport' function attribute */
+#define HAVE_FUNC_ATTRIBUTE_DLLEXPORT 1
+
+/* Define to 1 if the system has the `dllimport' function attribute */
+#define HAVE_FUNC_ATTRIBUTE_DLLIMPORT 1
+
+/* Define to 1 if the system has the `visibility' function attribute */
+#define HAVE_FUNC_ATTRIBUTE_VISIBILITY 1
+
+/* Define this symbol if the BSD getentropy system call is available */
+/* #undef HAVE_GETENTROPY */
+
+/* Define this symbol if the BSD getentropy system call is available with
+   sys/random.h */
+/* #undef HAVE_GETENTROPY_RAND */
+
+/* Define this symbol if gmtime_r is available */
+/* #undef HAVE_GMTIME_R */
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define to 1 if you have the `advapi32' library (-ladvapi32). */
+#define HAVE_LIBADVAPI32 1
+
+/* Define to 1 if you have the `comctl32' library (-lcomctl32). */
+#define HAVE_LIBCOMCTL32 1
+
+/* Define to 1 if you have the `comdlg32' library (-lcomdlg32). */
+#define HAVE_LIBCOMDLG32 1
+
+/* Define to 1 if you have the `crypt32' library (-lcrypt32). */
+#define HAVE_LIBCRYPT32 1
+
+/* Define to 1 if you have the `gdi32' library (-lgdi32). */
+#define HAVE_LIBGDI32 1
+
+/* Define to 1 if you have the `imm32' library (-limm32). */
+#define HAVE_LIBIMM32 1
+
+/* Define to 1 if you have the `iphlpapi' library (-liphlpapi). */
+#define HAVE_LIBIPHLPAPI 1
+
+/* Define to 1 if you have the `kernel32' library (-lkernel32). */
+#define HAVE_LIBKERNEL32 1
+
+/* Define to 1 if you have the `mingwthrd' library (-lmingwthrd). */
+#define HAVE_LIBMINGWTHRD 1
+
+/* Define to 1 if you have the `mswsock' library (-lmswsock). */
+#define HAVE_LIBMSWSOCK 1
+
+/* Define to 1 if you have the `ole32' library (-lole32). */
+#define HAVE_LIBOLE32 1
+
+/* Define to 1 if you have the `oleaut32' library (-loleaut32). */
+#define HAVE_LIBOLEAUT32 1
+
+/* Define to 1 if you have the `rpcrt4' library (-lrpcrt4). */
+#define HAVE_LIBRPCRT4 1
+
+/* Define to 1 if you have the `rt' library (-lrt). */
+/* #undef HAVE_LIBRT */
+
+/* Define to 1 if you have the `shell32' library (-lshell32). */
+#define HAVE_LIBSHELL32 1
+
+/* Define to 1 if you have the `shlwapi' library (-lshlwapi). */
+#define HAVE_LIBSHLWAPI 1
+
+/* Define to 1 if you have the `ssp' library (-lssp). */
+#define HAVE_LIBSSP 1
+
+/* Define to 1 if you have the `user32' library (-luser32). */
+#define HAVE_LIBUSER32 1
+
+/* Define to 1 if you have the `uuid' library (-luuid). */
+#define HAVE_LIBUUID 1
+
+/* Define to 1 if you have the `winmm' library (-lwinmm). */
+#define HAVE_LIBWINMM 1
+
+/* Define to 1 if you have the `winspool' library (-lwinspool). */
+#define HAVE_LIBWINSPOOL 1
+
+/* Define to 1 if you have the `ws2_32' library (-lws2_32). */
+#define HAVE_LIBWS2_32 1
+
+/* Define to 1 if you have the `z ' library (-lz ). */
+#define HAVE_LIBZ_ 1
+
+/* Define this symbol if you have malloc_info */
+/* #undef HAVE_MALLOC_INFO */
+
+/* Define this symbol if you have mallopt with M_ARENA_MAX */
+/* #undef HAVE_MALLOPT_ARENA_MAX */
+
+/* Define to 1 if you have the <memory.h> header file. */
+#define HAVE_MEMORY_H 1
+
+/* Define to 1 if you have the <miniupnpc/miniupnpc.h> header file. */
+#define HAVE_MINIUPNPC_MINIUPNPC_H 1
+
+/* Define to 1 if you have the <miniupnpc/miniwget.h> header file. */
+#define HAVE_MINIUPNPC_MINIWGET_H 1
+
+/* Define to 1 if you have the <miniupnpc/upnpcommands.h> header file. */
+#define HAVE_MINIUPNPC_UPNPCOMMANDS_H 1
+
+/* Define to 1 if you have the <miniupnpc/upnperrors.h> header file. */
+#define HAVE_MINIUPNPC_UPNPERRORS_H 1
+
+/* Define if you have POSIX threads libraries and header files. */
+#define HAVE_PTHREAD 1
+
+/* Have PTHREAD_PRIO_INHERIT. */
+#define HAVE_PTHREAD_PRIO_INHERIT 1
+
+/* Define to 1 if you have the <rapidcheck.h> header file. */
+/* #undef HAVE_RAPIDCHECK_H */
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdio.h> header file. */
+#define HAVE_STDIO_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the `std::system' function. */
+#define HAVE_STD__SYSTEM 1
+
+/* Define to 1 if you have the `strerror_r' function. */
+/* #undef HAVE_STRERROR_R */
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define this symbol if the BSD sysctl(KERN_ARND) is available */
+/* #undef HAVE_SYSCTL_ARND */
+
+/* std::system or ::wsystem */
+#define HAVE_SYSTEM HAVE_STD__SYSTEM || HAVE_WSYSTEM
+
+/* Define to 1 if you have the <sys/endian.h> header file. */
+/* #undef HAVE_SYS_ENDIAN_H */
+
+/* Define this symbol if the Linux getrandom system call is available */
+/* #undef HAVE_SYS_GETRANDOM */
+
+/* Define to 1 if you have the <sys/prctl.h> header file. */
+/* #undef HAVE_SYS_PRCTL_H */
+
+/* Define to 1 if you have the <sys/select.h> header file. */
+/* #undef HAVE_SYS_SELECT_H */
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define if thread_local is supported. */
+/* #undef HAVE_THREAD_LOCAL */
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H 1
+
+/* Define if the visibility attribute is supported. */
+#define HAVE_VISIBILITY_ATTRIBUTE 1
+
+/* Define this symbol if boost sleep works */
+/* #undef HAVE_WORKING_BOOST_SLEEP */
+
+/* Define this symbol if boost sleep_for works */
+#define HAVE_WORKING_BOOST_SLEEP_FOR 1
+
+/* Define to 1 if you have the `::wsystem' function. */
+/* #undef HAVE_WSYSTEM */
+
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
+#define LT_OBJDIR ".libs/"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT ""
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "Newyorkcoin"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "Newyorkcoin 0.19.0.1"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "newyorkcoin"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL "http://nycoin.community/"
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "0.19.0.1"
+
+/* Define to necessary symbol if this constant uses a non-standard name on
+   your system. */
+/* #undef PTHREAD_CREATE_JOINABLE */
+
+/* Define this symbol if the qt platform is cocoa */
+/* #undef QT_QPA_PLATFORM_COCOA */
+
+/* Define this symbol if the minimal qt platform exists */
+#define QT_QPA_PLATFORM_MINIMAL 1
+
+/* Define this symbol if the qt platform is windows */
+#define QT_QPA_PLATFORM_WINDOWS 1
+
+/* Define this symbol if the qt platform is xcb */
+/* #undef QT_QPA_PLATFORM_XCB */
+
+/* Define this symbol if qt plugins are static */
+#define QT_STATICPLUGIN 1
+
+/* Define to 1 if you have the ANSI C header files. */
+#define STDC_HEADERS 1
+
+/* Define to 1 if strerror_r returns char *. */
+/* #undef STRERROR_R_CHAR_P */
+
+/* Define this symbol to build in assembly routines */
+#define USE_ASM 1
+
+/* Define this symbol if coverage is enabled */
+/* #undef USE_COVERAGE */
+
+/* Define if dbus support should be compiled in */
+/* #undef USE_DBUS */
+
+/* Define if QR support should be compiled in */
+#define USE_QRCODE 1
+
+/* Define if SSE2 support should be compiled in */
+/* #undef USE_SSE2 */
+
+/* UPnP support not compiled if undefined, otherwise value (0 or 1) determines
+   default state */
+#define USE_UPNP 0
+
+/* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
+   significant byte first (like Motorola and SPARC, unlike Intel). */
+#if defined AC_APPLE_UNIVERSAL_BUILD
+# if defined __BIG_ENDIAN__
+#  define WORDS_BIGENDIAN 1
+# endif
+#else
+# ifndef WORDS_BIGENDIAN
+/* #  undef WORDS_BIGENDIAN */
+# endif
+#endif
+
+/* Enable large inode numbers on Mac OS X 10.5.  */
+#ifndef _DARWIN_USE_64_BIT_INODE
+# define _DARWIN_USE_64_BIT_INODE 1
+#endif
+
+/* Number of bits in a file offset, on hosts where this is settable. */
+#define _FILE_OFFSET_BITS 64
+
+/* Define for large files, on AIX-style hosts. */
+/* #undef _LARGE_FILES */
+
+#endif //BITCOIN_CONFIG_H

--- a/src/config/newyorkcoin-config.h.in
+++ b/src/config/newyorkcoin-config.h.in
@@ -1,0 +1,466 @@
+/* src/config/newyorkcoin-config.h.in.  Generated from configure.ac by autoheader.  */
+
+#ifndef BITCOIN_CONFIG_H
+
+#define BITCOIN_CONFIG_H
+
+/* Define if building universal (internal helper macro) */
+#undef AC_APPLE_UNIVERSAL_BUILD
+
+/* Define this symbol if type char equals int8_t */
+#undef CHAR_EQUALS_INT8
+
+/* Version Build */
+#undef CLIENT_VERSION_BUILD
+
+/* Version is release */
+#undef CLIENT_VERSION_IS_RELEASE
+
+/* Major version */
+#undef CLIENT_VERSION_MAJOR
+
+/* Minor version */
+#undef CLIENT_VERSION_MINOR
+
+/* Build revision */
+#undef CLIENT_VERSION_REVISION
+
+/* Copyright holder(s) before %s replacement */
+#undef COPYRIGHT_HOLDERS
+
+/* Copyright holder(s) */
+#undef COPYRIGHT_HOLDERS_FINAL
+
+/* Replacement for %s in copyright holders string */
+#undef COPYRIGHT_HOLDERS_SUBSTITUTION
+
+/* Copyright year */
+#undef COPYRIGHT_YEAR
+
+/* Define this symbol to build code that uses AVX2 intrinsics */
+#undef ENABLE_AVX2
+
+/* Define if BIP70 support should be compiled in */
+#undef ENABLE_BIP70
+
+/* Define this symbol to build code that uses SHA-NI intrinsics */
+#undef ENABLE_SHANI
+
+/* Define this symbol to build code that uses SSE4.1 intrinsics */
+#undef ENABLE_SSE41
+
+/* Define to 1 to enable wallet functions */
+#undef ENABLE_WALLET
+
+/* Define to 1 to enable ZMQ functions */
+#undef ENABLE_ZMQ
+
+/* parameter and return value type for __fdelt_chk */
+#undef FDELT_TYPE
+
+/* define if the Boost library is available */
+#undef HAVE_BOOST
+
+/* define if the Boost::Chrono library is available */
+#undef HAVE_BOOST_CHRONO
+
+/* define if the Boost::Filesystem library is available */
+#undef HAVE_BOOST_FILESYSTEM
+
+/* define if the Boost::System library is available */
+#undef HAVE_BOOST_SYSTEM
+
+/* define if the Boost::Thread library is available */
+#undef HAVE_BOOST_THREAD
+
+/* define if the Boost::Unit_Test_Framework library is available */
+#undef HAVE_BOOST_UNIT_TEST_FRAMEWORK
+
+/* Define to 1 if you have the <byteswap.h> header file. */
+#undef HAVE_BYTESWAP_H
+
+/* Define this symbol if the consensus lib has been built */
+#undef HAVE_CONSENSUS_LIB
+
+/* Define this symbol if FD_ZERO is dependent of a memcpy declaration being
+   available */
+#undef HAVE_CSTRING_DEPENDENT_FD_ZERO
+
+/* define if the compiler supports basic C++11 syntax */
+#undef HAVE_CXX11
+
+/* Define to 1 if you have the declaration of `be16toh', and to 0 if you
+   don't. */
+#undef HAVE_DECL_BE16TOH
+
+/* Define to 1 if you have the declaration of `be32toh', and to 0 if you
+   don't. */
+#undef HAVE_DECL_BE32TOH
+
+/* Define to 1 if you have the declaration of `be64toh', and to 0 if you
+   don't. */
+#undef HAVE_DECL_BE64TOH
+
+/* Define to 1 if you have the declaration of `bswap_16', and to 0 if you
+   don't. */
+#undef HAVE_DECL_BSWAP_16
+
+/* Define to 1 if you have the declaration of `bswap_32', and to 0 if you
+   don't. */
+#undef HAVE_DECL_BSWAP_32
+
+/* Define to 1 if you have the declaration of `bswap_64', and to 0 if you
+   don't. */
+#undef HAVE_DECL_BSWAP_64
+
+/* Define to 1 if you have the declaration of `daemon', and to 0 if you don't.
+   */
+#undef HAVE_DECL_DAEMON
+
+/* Define to 1 if you have the declaration of `EVP_MD_CTX_new', and to 0 if
+   you don't. */
+#undef HAVE_DECL_EVP_MD_CTX_NEW
+
+/* Define to 1 if you have the declaration of `freeifaddrs', and to 0 if you
+   don't. */
+#undef HAVE_DECL_FREEIFADDRS
+
+/* Define to 1 if you have the declaration of `getifaddrs', and to 0 if you
+   don't. */
+#undef HAVE_DECL_GETIFADDRS
+
+/* Define to 1 if you have the declaration of `htobe16', and to 0 if you
+   don't. */
+#undef HAVE_DECL_HTOBE16
+
+/* Define to 1 if you have the declaration of `htobe32', and to 0 if you
+   don't. */
+#undef HAVE_DECL_HTOBE32
+
+/* Define to 1 if you have the declaration of `htobe64', and to 0 if you
+   don't. */
+#undef HAVE_DECL_HTOBE64
+
+/* Define to 1 if you have the declaration of `htole16', and to 0 if you
+   don't. */
+#undef HAVE_DECL_HTOLE16
+
+/* Define to 1 if you have the declaration of `htole32', and to 0 if you
+   don't. */
+#undef HAVE_DECL_HTOLE32
+
+/* Define to 1 if you have the declaration of `htole64', and to 0 if you
+   don't. */
+#undef HAVE_DECL_HTOLE64
+
+/* Define to 1 if you have the declaration of `le16toh', and to 0 if you
+   don't. */
+#undef HAVE_DECL_LE16TOH
+
+/* Define to 1 if you have the declaration of `le32toh', and to 0 if you
+   don't. */
+#undef HAVE_DECL_LE32TOH
+
+/* Define to 1 if you have the declaration of `le64toh', and to 0 if you
+   don't. */
+#undef HAVE_DECL_LE64TOH
+
+/* Define to 1 if you have the declaration of `strerror_r', and to 0 if you
+   don't. */
+#undef HAVE_DECL_STRERROR_R
+
+/* Define to 1 if you have the declaration of `strnlen', and to 0 if you
+   don't. */
+#undef HAVE_DECL_STRNLEN
+
+/* Define to 1 if you have the declaration of `__builtin_clz', and to 0 if you
+   don't. */
+#undef HAVE_DECL___BUILTIN_CLZ
+
+/* Define to 1 if you have the declaration of `__builtin_clzl', and to 0 if
+   you don't. */
+#undef HAVE_DECL___BUILTIN_CLZL
+
+/* Define to 1 if you have the declaration of `__builtin_clzll', and to 0 if
+   you don't. */
+#undef HAVE_DECL___BUILTIN_CLZLL
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#undef HAVE_DLFCN_H
+
+/* Define to 1 if you have the <endian.h> header file. */
+#undef HAVE_ENDIAN_H
+
+/* Define to 1 if the system has the `dllexport' function attribute */
+#undef HAVE_FUNC_ATTRIBUTE_DLLEXPORT
+
+/* Define to 1 if the system has the `dllimport' function attribute */
+#undef HAVE_FUNC_ATTRIBUTE_DLLIMPORT
+
+/* Define to 1 if the system has the `visibility' function attribute */
+#undef HAVE_FUNC_ATTRIBUTE_VISIBILITY
+
+/* Define this symbol if the BSD getentropy system call is available */
+#undef HAVE_GETENTROPY
+
+/* Define this symbol if the BSD getentropy system call is available with
+   sys/random.h */
+#undef HAVE_GETENTROPY_RAND
+
+/* Define this symbol if gmtime_r is available */
+#undef HAVE_GMTIME_R
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#undef HAVE_INTTYPES_H
+
+/* Define to 1 if you have the `advapi32' library (-ladvapi32). */
+#undef HAVE_LIBADVAPI32
+
+/* Define to 1 if you have the `comctl32' library (-lcomctl32). */
+#undef HAVE_LIBCOMCTL32
+
+/* Define to 1 if you have the `comdlg32' library (-lcomdlg32). */
+#undef HAVE_LIBCOMDLG32
+
+/* Define to 1 if you have the `crypt32' library (-lcrypt32). */
+#undef HAVE_LIBCRYPT32
+
+/* Define to 1 if you have the `gdi32' library (-lgdi32). */
+#undef HAVE_LIBGDI32
+
+/* Define to 1 if you have the `imm32' library (-limm32). */
+#undef HAVE_LIBIMM32
+
+/* Define to 1 if you have the `iphlpapi' library (-liphlpapi). */
+#undef HAVE_LIBIPHLPAPI
+
+/* Define to 1 if you have the `kernel32' library (-lkernel32). */
+#undef HAVE_LIBKERNEL32
+
+/* Define to 1 if you have the `mingwthrd' library (-lmingwthrd). */
+#undef HAVE_LIBMINGWTHRD
+
+/* Define to 1 if you have the `mswsock' library (-lmswsock). */
+#undef HAVE_LIBMSWSOCK
+
+/* Define to 1 if you have the `ole32' library (-lole32). */
+#undef HAVE_LIBOLE32
+
+/* Define to 1 if you have the `oleaut32' library (-loleaut32). */
+#undef HAVE_LIBOLEAUT32
+
+/* Define to 1 if you have the `rpcrt4' library (-lrpcrt4). */
+#undef HAVE_LIBRPCRT4
+
+/* Define to 1 if you have the `rt' library (-lrt). */
+#undef HAVE_LIBRT
+
+/* Define to 1 if you have the `shell32' library (-lshell32). */
+#undef HAVE_LIBSHELL32
+
+/* Define to 1 if you have the `shlwapi' library (-lshlwapi). */
+#undef HAVE_LIBSHLWAPI
+
+/* Define to 1 if you have the `ssp' library (-lssp). */
+#undef HAVE_LIBSSP
+
+/* Define to 1 if you have the `user32' library (-luser32). */
+#undef HAVE_LIBUSER32
+
+/* Define to 1 if you have the `uuid' library (-luuid). */
+#undef HAVE_LIBUUID
+
+/* Define to 1 if you have the `winmm' library (-lwinmm). */
+#undef HAVE_LIBWINMM
+
+/* Define to 1 if you have the `winspool' library (-lwinspool). */
+#undef HAVE_LIBWINSPOOL
+
+/* Define to 1 if you have the `ws2_32' library (-lws2_32). */
+#undef HAVE_LIBWS2_32
+
+/* Define to 1 if you have the `z ' library (-lz ). */
+#undef HAVE_LIBZ_
+
+/* Define this symbol if you have malloc_info */
+#undef HAVE_MALLOC_INFO
+
+/* Define this symbol if you have mallopt with M_ARENA_MAX */
+#undef HAVE_MALLOPT_ARENA_MAX
+
+/* Define to 1 if you have the <memory.h> header file. */
+#undef HAVE_MEMORY_H
+
+/* Define to 1 if you have the <miniupnpc/miniupnpc.h> header file. */
+#undef HAVE_MINIUPNPC_MINIUPNPC_H
+
+/* Define to 1 if you have the <miniupnpc/miniwget.h> header file. */
+#undef HAVE_MINIUPNPC_MINIWGET_H
+
+/* Define to 1 if you have the <miniupnpc/upnpcommands.h> header file. */
+#undef HAVE_MINIUPNPC_UPNPCOMMANDS_H
+
+/* Define to 1 if you have the <miniupnpc/upnperrors.h> header file. */
+#undef HAVE_MINIUPNPC_UPNPERRORS_H
+
+/* Define if you have POSIX threads libraries and header files. */
+#undef HAVE_PTHREAD
+
+/* Have PTHREAD_PRIO_INHERIT. */
+#undef HAVE_PTHREAD_PRIO_INHERIT
+
+/* Define to 1 if you have the <rapidcheck.h> header file. */
+#undef HAVE_RAPIDCHECK_H
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#undef HAVE_STDINT_H
+
+/* Define to 1 if you have the <stdio.h> header file. */
+#undef HAVE_STDIO_H
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#undef HAVE_STDLIB_H
+
+/* Define to 1 if you have the `std::system' function. */
+#undef HAVE_STD__SYSTEM
+
+/* Define to 1 if you have the `strerror_r' function. */
+#undef HAVE_STRERROR_R
+
+/* Define to 1 if you have the <strings.h> header file. */
+#undef HAVE_STRINGS_H
+
+/* Define to 1 if you have the <string.h> header file. */
+#undef HAVE_STRING_H
+
+/* Define this symbol if the BSD sysctl(KERN_ARND) is available */
+#undef HAVE_SYSCTL_ARND
+
+/* std::system or ::wsystem */
+#undef HAVE_SYSTEM
+
+/* Define to 1 if you have the <sys/endian.h> header file. */
+#undef HAVE_SYS_ENDIAN_H
+
+/* Define this symbol if the Linux getrandom system call is available */
+#undef HAVE_SYS_GETRANDOM
+
+/* Define to 1 if you have the <sys/prctl.h> header file. */
+#undef HAVE_SYS_PRCTL_H
+
+/* Define to 1 if you have the <sys/select.h> header file. */
+#undef HAVE_SYS_SELECT_H
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#undef HAVE_SYS_STAT_H
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#undef HAVE_SYS_TYPES_H
+
+/* Define if thread_local is supported. */
+#undef HAVE_THREAD_LOCAL
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#undef HAVE_UNISTD_H
+
+/* Define if the visibility attribute is supported. */
+#undef HAVE_VISIBILITY_ATTRIBUTE
+
+/* Define this symbol if boost sleep works */
+#undef HAVE_WORKING_BOOST_SLEEP
+
+/* Define this symbol if boost sleep_for works */
+#undef HAVE_WORKING_BOOST_SLEEP_FOR
+
+/* Define to 1 if you have the `::wsystem' function. */
+#undef HAVE_WSYSTEM
+
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
+#undef LT_OBJDIR
+
+/* Define to the address where bug reports for this package should be sent. */
+#undef PACKAGE_BUGREPORT
+
+/* Define to the full name of this package. */
+#undef PACKAGE_NAME
+
+/* Define to the full name and version of this package. */
+#undef PACKAGE_STRING
+
+/* Define to the one symbol short name of this package. */
+#undef PACKAGE_TARNAME
+
+/* Define to the home page for this package. */
+#undef PACKAGE_URL
+
+/* Define to the version of this package. */
+#undef PACKAGE_VERSION
+
+/* Define to necessary symbol if this constant uses a non-standard name on
+   your system. */
+#undef PTHREAD_CREATE_JOINABLE
+
+/* Define this symbol if the qt platform is cocoa */
+#undef QT_QPA_PLATFORM_COCOA
+
+/* Define this symbol if the minimal qt platform exists */
+#undef QT_QPA_PLATFORM_MINIMAL
+
+/* Define this symbol if the qt platform is windows */
+#undef QT_QPA_PLATFORM_WINDOWS
+
+/* Define this symbol if the qt platform is xcb */
+#undef QT_QPA_PLATFORM_XCB
+
+/* Define this symbol if qt plugins are static */
+#undef QT_STATICPLUGIN
+
+/* Define to 1 if you have the ANSI C header files. */
+#undef STDC_HEADERS
+
+/* Define to 1 if strerror_r returns char *. */
+#undef STRERROR_R_CHAR_P
+
+/* Define this symbol to build in assembly routines */
+#undef USE_ASM
+
+/* Define this symbol if coverage is enabled */
+#undef USE_COVERAGE
+
+/* Define if dbus support should be compiled in */
+#undef USE_DBUS
+
+/* Define if QR support should be compiled in */
+#undef USE_QRCODE
+
+/* Define if SSE2 support should be compiled in */
+#undef USE_SSE2
+
+/* UPnP support not compiled if undefined, otherwise value (0 or 1) determines
+   default state */
+#undef USE_UPNP
+
+/* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
+   significant byte first (like Motorola and SPARC, unlike Intel). */
+#if defined AC_APPLE_UNIVERSAL_BUILD
+# if defined __BIG_ENDIAN__
+#  define WORDS_BIGENDIAN 1
+# endif
+#else
+# ifndef WORDS_BIGENDIAN
+#  undef WORDS_BIGENDIAN
+# endif
+#endif
+
+/* Enable large inode numbers on Mac OS X 10.5.  */
+#ifndef _DARWIN_USE_64_BIT_INODE
+# define _DARWIN_USE_64_BIT_INODE 1
+#endif
+
+/* Number of bits in a file offset, on hosts where this is settable. */
+#undef _FILE_OFFSET_BITS
+
+/* Define for large files, on AIX-style hosts. */
+#undef _LARGE_FILES
+
+#endif //BITCOIN_CONFIG_H

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -271,7 +271,7 @@ class CTransaction
 {
 public:
     // Default transaction version.
-    static const int32_t CURRENT_VERSION=2;
+    static const int32_t CURRENT_VERSION=1;
 
     // Changing the default transaction version requires a two step process: first
     // adapting relay policy by bumping MAX_STANDARD_VERSION, and then later date

--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -93,10 +93,12 @@ void MilliSleep(int64_t n)
 std::string FormatISO8601DateTime(int64_t nTime) {
     struct tm ts;
     time_t time_val = nTime;
-#ifdef _MSC_VER
-    gmtime_s(&ts, &time_val);
-#else
+#ifdef HAVE_GMTIME_R
     gmtime_r(&time_val, &ts);
+    
+#else
+    gmtime_s(&ts, &time_val);
+    
 #endif
     return strprintf("%04i-%02i-%02iT%02i:%02i:%02iZ", ts.tm_year + 1900, ts.tm_mon + 1, ts.tm_mday, ts.tm_hour, ts.tm_min, ts.tm_sec);
 }
@@ -104,10 +106,11 @@ std::string FormatISO8601DateTime(int64_t nTime) {
 std::string FormatISO8601Date(int64_t nTime) {
     struct tm ts;
     time_t time_val = nTime;
-#ifdef _MSC_VER
-    gmtime_s(&ts, &time_val);
-#else
+#ifdef HAVE_GMTIME_R
     gmtime_r(&time_val, &ts);
+    
+#else
+    gmtime_s(&ts, &time_val);
 #endif
     return strprintf("%04i-%02i-%02i", ts.tm_year + 1900, ts.tm_mon + 1, ts.tm_mday);
 }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -68,7 +68,7 @@ static const CAmount DEFAULT_FALLBACK_FEE = 20000;
 //! -discardfee default
 static const CAmount DEFAULT_DISCARD_FEE = 10000;
 //! -mintxfee default
-static const CAmount DEFAULT_TRANSACTION_MINFEE = 1000;
+static const CAmount DEFAULT_TRANSACTION_MINFEE = 0;
 //! minimum recommended increment for BIP 125 replacement txs
 static const CAmount WALLET_INCREMENTAL_RELAY_FEE = 5000;
 //! Default for -spendzeroconfchange


### PR DESCRIPTION
Changed TX version to 1 to allow 2.0 code to send tx to 1.3.10 wallets.

Additional code added to configure.ac to allow a workaround for windows builds and issues surrounding time.h.